### PR TITLE
Argparse takes arguments as strings

### DIFF
--- a/tiki/__init__.py
+++ b/tiki/__init__.py
@@ -28,7 +28,7 @@ def snort():
 
 def eyes(lr, lg, lb, rr, rg, rb):
     # Maximum value for these is 63, anymore and it breaks with a stupid error
-    if max([lr, lg, lb, rr, rg, rb]) > 63:
+    if max(map(int, [lr, lg, lb, rr, rg, rb])) > 63:
         print("Value out of range 0-63")
     else:
         get(


### PR DESCRIPTION
I've tried running it using the latest `requests`. `snort` function seems to be alright, `eyes` always print the out of range message because `argparse` arguments are treated as strings. 